### PR TITLE
Add derive feature to serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["hwid", "machineid", "hardware-id", "machineuid", "uuid"]
 [dependencies]
 sysinfo = "0.22.5"
 whoami = "1.2.1"
-serde = "1.0.133"
+serde = {version="1.0.133", features = ["derive"]}
 serde_json = "1.0.74"
 rust-crypto = "0.2.36"
 hex = "0.4.3"


### PR DESCRIPTION
This fixes an issue when this library is used in rust 2021 projects.

```
error: cannot find derive macro `Deserialize` in this scope
  --> /home/kbloom/.cargo/registry/src/github.com-1ecc6299db9ec823/machineid-rs-1.2.1/src/linux.rs:19:10
   |
19 | #[derive(Deserialize)]
   |          ^^^^^^^^^^^
   |
```