### PR TITLE
add get_hwid for windows i686

### DIFF
--- a/src/windows.rs
+++ b/src/windows.rs
@@ -15,9 +15,23 @@ thread_local! {
 }
 
 #[cfg(target_os = "windows")]
+#[cfg(target_arch = "x86_64")]
 pub fn get_hwid() -> Result<String, HWIDError> {
     let rkey =
         RegKey::predef(HKEY_LOCAL_MACHINE).open_subkey("SOFTWARE\\Microsoft\\Cryptography")?;
+    let id = rkey.get_value("MachineGuid")?;
+    Ok(id)
+}
+
+#[cfg(target_os = "windows")]
+#[cfg(target_arch = "x86")]
+pub fn get_hwid() -> Result<String, HWIDError> {
+    use winreg::enums::{KEY_READ, KEY_WOW64_64KEY};
+
+    let rkey = RegKey::predef(HKEY_LOCAL_MACHINE)
+        .open_subkey_with_flags("SOFTWARE\\Microsoft\\Cryptography",
+        KEY_READ|KEY_WOW64_64KEY)?;
+
     let id = rkey.get_value("MachineGuid")?;
     Ok(id)
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -15,22 +15,13 @@ thread_local! {
 }
 
 #[cfg(target_os = "windows")]
-#[cfg(target_arch = "x86_64")]
-pub fn get_hwid() -> Result<String, HWIDError> {
-    let rkey =
-        RegKey::predef(HKEY_LOCAL_MACHINE).open_subkey("SOFTWARE\\Microsoft\\Cryptography")?;
-    let id = rkey.get_value("MachineGuid")?;
-    Ok(id)
-}
-
-#[cfg(target_os = "windows")]
-#[cfg(target_arch = "x86")]
 pub fn get_hwid() -> Result<String, HWIDError> {
     use winreg::enums::{KEY_READ, KEY_WOW64_64KEY};
 
-    let rkey = RegKey::predef(HKEY_LOCAL_MACHINE)
-        .open_subkey_with_flags("SOFTWARE\\Microsoft\\Cryptography",
-        KEY_READ|KEY_WOW64_64KEY)?;
+    let rkey = RegKey::predef(HKEY_LOCAL_MACHINE).open_subkey_with_flags(
+        "SOFTWARE\\Microsoft\\Cryptography",
+        KEY_READ | KEY_WOW64_64KEY,
+    )?;
 
     let id = rkey.get_value("MachineGuid")?;
     Ok(id)


### PR DESCRIPTION
While trying an i686 application on x86_64 Windows, I found out this issue. It turns out that on [Windows Registry](https://learn.microsoft.com/en-us/windows/win32/winprog64/accessing-an-alternate-registry-view) you still can get the 64bits data on a 32bits application but you need to do a different call.