### PR TITLE
lib: Move FileToken to use String

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ pub enum HWIDComponent {
     /// CPU Vendor ID
     CPUID,
     /// The contents of a file
-    FileToken(&'static str),
+    FileToken(String),
     /// UUID of the root disk
     DriveSerial,
 }
@@ -265,7 +265,7 @@ mod test {
             .add_component(HWIDComponent::CPUID)
             .add_component(HWIDComponent::DriveSerial)
             .add_component(HWIDComponent::MacAddress)
-            .add_component(HWIDComponent::FileToken("test.txt"))
+            .add_component(HWIDComponent::FileToken("test.txt".into()))
             .add_component(HWIDComponent::Username)
             .add_component(HWIDComponent::MachineName);
         let hash = builder.build("mykey").unwrap();
@@ -283,7 +283,7 @@ mod test {
             .add_component(HWIDComponent::CPUID)
             .add_component(HWIDComponent::DriveSerial)
             .add_component(HWIDComponent::MacAddress)
-            .add_component(HWIDComponent::FileToken("test.txt"))
+            .add_component(HWIDComponent::FileToken("test.txt".into()))
             .add_component(HWIDComponent::Username)
             .add_component(HWIDComponent::MachineName);
         let hash = builder.build("mykey").unwrap();
@@ -301,7 +301,7 @@ mod test {
             .add_component(HWIDComponent::CPUID)
             .add_component(HWIDComponent::DriveSerial)
             .add_component(HWIDComponent::MacAddress)
-            .add_component(HWIDComponent::FileToken("test.txt"))
+            .add_component(HWIDComponent::FileToken("test.txt".into()))
             .add_component(HWIDComponent::Username)
             .add_component(HWIDComponent::MachineName);
         let hash = builder.build("mykey").unwrap();


### PR DESCRIPTION
Using `&'static str` makes it a bit harder to manage lifetimes. Using String objects makes the API simpler to use and moving the ownership to the token. 