### PR TITLE
linux: Get only the first default interface from ip route command

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -127,8 +127,10 @@ pub(crate) fn get_mac_address() -> Result<String, HWIDError> {
         }
     }
 
-    // If everything just fails, we get the default network interface
-    get_mac_addressof_interface(&run_command("ip route show default | awk '/default/ {print $5}'")?)
+    // If everything just fails, we get the (first) default network interface
+    get_mac_addressof_interface(&run_command(
+        "ip route show default | awk '/default/ {print $5; exit}'",
+    )?)
 }
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
Closes #16 