### PR TITLE
default-features to false for sysinfo dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["authentication", "config", "accessibility"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sysinfo = "0.29.6"
+sysinfo = {version = "0.29.6", default-features = false }
 whoami = "1.2.1"
 serde = { version = "1.0.133", features = ["derive"] }
 hex = "0.4.3"


### PR DESCRIPTION
Sysinfo has a default feature called "multithread" that pulls in rayon as a dependency. I believe this feature is not used by machineid-rs and the dependency could be disabled by default.