### PR TITLE
Trim newlines from machine ID file read on linux + support plain sha256 digest

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -150,7 +150,7 @@ fn get_file_content(path: &str) -> Result<String, HWIDError> {
 pub(crate) fn get_hwid() -> Result<String, HWIDError> {
     for path in MACHINE_ID_FILES.iter() {
         if std::path::Path::new(path).exists() {
-            let content = get_file_content(path)?;
+            let content = get_file_content(path)?.trim().to_string();
             return Ok(content);
         }
     }


### PR DESCRIPTION
A newline character is read from the machine ID file on Linux and this newline is included in the hash of the ID, changing its value.  This PR trims the `hwid` result before returning to remove the newline.

There are likely some backwards compatibility issues to consider here as this will change the machine IDs that are output from this library.